### PR TITLE
Set CSRF token to never expire.

### DIFF
--- a/routes18xxweb/settings.py
+++ b/routes18xxweb/settings.py
@@ -7,6 +7,7 @@ EXPLAIN_TEMPLATE_LOADING = False
 
 # WTForms
 WTF_CSRF_ENABLED = True
+WTF_CSRF_TIME_LIMIT = None
 
 # SendGrid
 MAIL_USERNAME = os.environ['EMAIL_USER']


### PR DESCRIPTION
This was causing BAD REQUEST errors after 30 minutes of app use, since
the token is dropped into the page and the page is never refreshed
during normal use.