### PR TITLE
Allow setting token and tile values without drawing.

### DIFF
--- a/routes18xxweb/templates/index.html
+++ b/routes18xxweb/templates/index.html
@@ -249,6 +249,9 @@ function loadGameState() {
             loadFromLocalStoragePrivateCompanies(),
             {% endif %}
         ).then(() => {
+            drawMap();
+            drawTokens();
+        }).then(() => {
             toggleEnableInput(true);
             appIsDoneLoading();
         });
@@ -299,6 +302,8 @@ $("#global-import-save").click(function() {
                             updateLocalStorageRemovedRailroads();
                             importPrivateCompanies($("#private-companies-import-export-textarea").val())
                                 .then(() => {
+                                    drawMap()
+                                    drawTokens();
                                     updateLocalStoragePrivateCompanies();
                                 })
                                 .then(() => {

--- a/routes18xxweb/templates/js/placed-tiles-map.js.html
+++ b/routes18xxweb/templates/js/placed-tiles-map.js.html
@@ -1111,9 +1111,6 @@ async function importTiles(importText) {
         tilesTable.push(row.map(value => value.toString()));
     });
 
-    drawMap();
-    drawTokens();
-
     return Promise.resolve();
 }
 

--- a/routes18xxweb/templates/js/private-companies-table.js.html
+++ b/routes18xxweb/templates/js/private-companies-table.js.html
@@ -114,7 +114,6 @@ function setPrivateCompanyOwner(privateCompanyRow, owner) {
                     }
                 } else {
                     setPrivateCompanyTokenCoord(privateCompanyRow, coords[0]);
-                    drawTokens();
                 }
 
                 resolve();
@@ -178,8 +177,6 @@ async function importPrivateCompanies(importText) {
                 console.warn(`Failed to import the owner of ${companyName}. Continuing...`);
             });
     });
-
-    drawTokens();
 }
 
 function preparePrivateCompaniesForExport(privateCompaniesTable) {
@@ -278,6 +275,7 @@ function removePrivateCompany(companyName) {
     var sourceRow = getPrivateCompanyRow(companyName);
     setPrivateCompanyTokenCoord(sourceRow, null);
     setPrivateCompanyOwner(sourceRow, null);
+    drawTokens();
     updateLocalStoragePrivateCompanies();
     updateLocalStorageRailroads();
 }
@@ -345,6 +343,7 @@ function populatePrivateCompanyOwnerDropdown(sourceRow) {
                         var oldCoord = sourceRow.attr("data-coord");
 
                         setPrivateCompanyOwner(sourceRow, $(this).attr("data-owner"));
+                        drawTokens();
 
                         sourceRow.find(".company-owner button").focus();
 

--- a/routes18xxweb/templates/js/railroads-table.js.html
+++ b/routes18xxweb/templates/js/railroads-table.js.html
@@ -231,7 +231,6 @@ function importRailroads(importText) {
             });
 
         removeAllPrivateCompanies(company => !getRailroads().includes(company[1]))
-        drawTokens();
 
         $("#calculate-submit").prop("disabled", !readyToSelectRailroad());
 

--- a/routes18xxweb/templates/js/removed-railroads-table.js.html
+++ b/routes18xxweb/templates/js/removed-railroads-table.js.html
@@ -87,8 +87,6 @@ function importRemovedRailroads(importText) {
                     $(`#removed-railroads button[data-railroad='${railroad}']`).remove()
                 });
 
-            drawTokens();
-
             updateLocalStorageRemovedRailroads();
         })
         .catch(function(jqXHR, textStatus, errorThrown) {


### PR DESCRIPTION
This eliminates a race condition from loading, which had been leaving
behind ghost tokens.