### PR TITLE
Draw thw tokens after updating the phase.

### DIFF
--- a/routes18xxweb/templates/js/railroads-table.js.html
+++ b/routes18xxweb/templates/js/railroads-table.js.html
@@ -341,6 +341,7 @@ function addTrainAndStationButtons(rowElement) {
                     removeAllPrivateCompanies(company => company[1] === $(this).parents("tr").attr("data-railroad"));
                     updateLocalStorageRailroads();
                     updatePhase();
+                    drawTokens();
                 }));
 
     if ($("#railroads-table").attr("data-disabled") === "true") {
@@ -735,6 +736,7 @@ $("#trains-modal-confirm").click(function() {
 
     updateLocalStorageRailroads();
     updatePhase();
+    drawTokens();
 });
 
 $("#stations-modal").on("show.bs.modal", function(event) {


### PR DESCRIPTION
This ensures that if the new phase toggles the privates between open and
closed, any tokens on the board are displayed or hidden as appropriate.

Resolves #70 