### PR TITLE
Add support for closing railroads.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-routes-18xx == 0.7.1
+routes-18xx == 0.8.1
 
 Flask == 1.1.2
 Flask-WTF==0.14.3

--- a/routes18xxweb/templates/index.html
+++ b/routes18xxweb/templates/index.html
@@ -42,15 +42,30 @@
         <div id="config-tabs-content" class="tab-content" style="margin-top: 15px;">
             <div class="tab-pane fade show active" id="railroad-table-tab-content" role="tabpanel" aria-labelledby="home-tab">
                 <table id="railroads-table"></table>
-                <div style="margin-top: 10px;">
+                <div>
+                    {% if closable_railroads -%}
+                    <div style="margin-top: 10px; float: left;">
+                        <h4>Closed Railroads</h4>
+                        <div class="dropdown" id="close-railroad-dropdown" style="margin-bottom: 5px;">
+                            <button class="btn btn-sm btn-danger dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <span class="oi oi-plus align-text-top"></span>
+                            </button>
+                            <div class="dropdown-menu" id="close-railroad-dropdown-list"></div>
+                        </div>
+                        <div id="closed-railroads"></div>
+                    </div>
+                    {% endif %}
                     {% if removable_railroads -%}
-                    <h4>Removed Railroads</h4>
-                    <div id="removed-railroads"></div>
-                    <div class="dropdown" id="remove-railroad-dropdown" style="margin-top: 5px;">
-                        <button class="btn btn-sm btn-info dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            <span class="oi oi-plus align-text-top"></span>
-                        </button>
-                        <div class="dropdown-menu" id="remove-railroad-dropdown-list"></div>
+                    <div style="margin-left: 20px; float: left;">&nbsp;</div>
+                    <div style="margin-top: 10px; float: left;">
+                        <h4>Removed Railroads</h4>
+                        <div class="dropdown" id="remove-railroad-dropdown" style="margin-bottom: 5px;">
+                            <button class="btn btn-sm btn-info dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <span class="oi oi-plus align-text-top"></span>
+                            </button>
+                            <div class="dropdown-menu" id="remove-railroad-dropdown-list"></div>
+                        </div>
+                        <div id="removed-railroads"></div>
                     </div>
                     {% endif %}
                 </div>
@@ -213,6 +228,7 @@ function toggleEnableInput(enable) {
     toggleEnableMap(enable);
     toggleEnableRailroads(enable);
     toggleEnableRemovedRailroads(enable);
+    toggleEnableClosedRailroads(enable);
     {%- if private_company_rownames %}
     toggleEnablePrivateCompanies(enable);
     {% endif %}
@@ -252,6 +268,7 @@ function loadGameState() {
             loadFromLocalStoragePlacedTiles(),
             loadFromLocalStorageRailroads(),
             loadFromLocalStorageRemovedRailroads(),
+            loadFromLocalStorageClosedRailroads(),
             {%- if private_company_rownames %}
             loadFromLocalStoragePrivateCompanies(),
             {% endif %}
@@ -295,25 +312,34 @@ $("#global-import-save").click(function() {
                     importRemovedRailroads($("#railroads-import-export-textarea").val())
                         .then(() => {
                             updateLocalStorageRemovedRailroads();
-                            importPrivateCompanies($("#private-companies-import-export-textarea").val())
+                            importClosedRailroads($("#railroads-import-export-textarea").val())
                                 .then(() => {
-                                    drawMap()
-                                    drawTokens();
-                                    updateLocalStoragePrivateCompanies();
-                                })
-                                .then(() => {
-                                    var allRailroads = getRailroads();
-                                    var allRemovedRailroads = getRemovedRailroads();
-                                    if (allRailroads.length + getRemovedRailroads().length > new Set(getRailroads().concat(getRemovedRailroads())).size) {
-                                        allRailroads.forEach(railroad => {
-                                            if (allRemovedRailroads.includes(railroad)) {
-                                                deleteRemovedRailroad(railroad);
+                                    updateLocalStorageClosedRailroads();
+                                    importPrivateCompanies($("#private-companies-import-export-textarea").val())
+                                        .then(() => {
+                                            drawMap()
+                                            drawTokens();
+                                            updateLocalStoragePrivateCompanies();
+                                        })
+                                        .then(() => {
+                                            var allRailroads = getRailroads();
+                                            var allRemovedRailroads = getRemovedRailroads();
+                                            var allClosedRailroads = getClosedRailroads();
+                                            if (allRailroads.length + allRemovedRailroads.length + allClosedRailroads.length >
+                                                    new Set(allRailroads.concat(allRemovedRailroads).concat(allClosedRailroads)).size) {
+                                                allRailroads.forEach(railroad => {
+                                                    if (allRemovedRailroads.includes(railroad)) {
+                                                        deleteRemovedRailroad(railroad);
+                                                    }
+                                                    if (allClosedRailroads.includes(railroad)) {
+                                                        deleteClosedRailroad(railroad);
+                                                    }
+                                                });
                                             }
-                                        });
-                                    }
 
-                                    toggleEnableInput(true);
-                                    appIsDoneLoading();
+                                            toggleEnableInput(true);
+                                            appIsDoneLoading();
+                                        });
                                 });
                         });
                 });
@@ -334,7 +360,8 @@ $("#global-import-export-modal").on("show.bs.modal", function() {
 
     $("#tiles-import-export-textarea").val("").val(prepareTilesForExport());
     $("#railroads-import-export-textarea").val(prepareRailroadsForExport()
-            + "\n" + prepareRemovedRailroadsForExport());
+            + "\n" + prepareRemovedRailroadsForExport()
+            + "\n" + prepareClosedRailroadsForExport());
     {%- if private_company_rownames %}
     $("#private-companies-import-export-textarea").val(preparePrivateCompaniesForExport());
     {% endif %}
@@ -371,6 +398,8 @@ if (remainingSpace < 300) {
 {% include "js/railroads-table.js.html" %}
 
 {% include "js/removed-railroads-table.js.html" %}
+
+{% include "js/closed-railroads-table.js.html" %}
 
 {% include "js/private-companies-table.js.html" %}
 

--- a/routes18xxweb/templates/js/calculate.js.html
+++ b/routes18xxweb/templates/js/calculate.js.html
@@ -178,6 +178,7 @@ function calculate() {
     var postData = {
         "railroads-json": JSON.stringify(railroadsTable),
         "removed-railroads-json": JSON.stringify(getRemovedRailroads()),
+        "closed-railroads-json": JSON.stringify(getClosedRailroads()),
         "private-companies-json": JSON.stringify(getPrivateCompaniesAsTable()),
         "board-state-json": JSON.stringify(getTilesAsTable()),
         "railroad-name": $("#calculate-dropdown").attr("data-selected")

--- a/routes18xxweb/templates/js/closed-railroads-table.js.html
+++ b/routes18xxweb/templates/js/closed-railroads-table.js.html
@@ -1,0 +1,150 @@
+function getClosedRailroads() {
+    return $("#closed-railroads button[data-railroad]").map((index, element) => $(element).attr("data-railroad")).toArray();
+}
+
+function getClosedRailroadsAsTable() {
+    var closedRailroadsTableData = [];
+    $("#closed-railroads button[data-railroad]").each((index, element) => {
+        return closedRailroadsTableData.push([
+            $(element).attr("data-railroad"),
+            $(element).attr("data-home")
+        ]);
+    });
+    return closedRailroadsTableData;
+}
+
+function deleteClosedRailroad(railroad) {
+    $(`#closed-railroads button[data-railroad='${railroad}']`).remove();
+
+    drawTokens();
+
+    updateLocalStorageClosedRailroads();
+}
+
+function addClosedRailroad(railroadName, homeCity) {
+    $("#closed-railroads")
+        .append($("<button></button>")
+            .addClass("btn btn-sm btn-outline-danger")
+            .attr("type", "button")
+            .attr("data-railroad", railroadName)
+            .attr("data-home", homeCity)
+            .css("margin-top", 5)
+            .css("display", "block")
+            .append($("<span></span>")
+                .addClass("oi oi-circle-x align-text-top")
+                .css("margin-right", 5))
+            .append($("<span></span>").text(railroadName))
+            .click(function() {
+                deleteClosedRailroad($(this).attr("data-railroad"));
+            }));
+
+    if ($("#closed-railroads").attr("data-disabled") === "true") {
+        $("#closed-railroads button").prop("disabled", true);
+    }
+}
+
+function updateLocalStorageClosedRailroads() {
+    setLocalStorage("closedRailroadsTable", getClosedRailroads());
+}
+
+function loadFromLocalStorageClosedRailroads() {
+    var rawClosedRailroadsTable = getLocalStorage("closedRailroadsTable");
+    if (rawClosedRailroadsTable !== undefined) {
+        return importClosedRailroads(prepareClosedRailroadsForExport(rawClosedRailroadsTable));
+    }
+    return Promise.resolve();
+}
+
+function importClosedRailroads(importText) {
+    var importRows = importText.trim().split("\n");
+    var closedRailroadRows = importRows
+        .map(row => row.split(";"))
+        // Since the railroads and closed railroads shared a text area, filter out the railroads
+        .filter(row => row.length >= 2 && !isEmpty(row[1]) && row[1].trim().toLowerCase() === "closed")
+        .map(row => row[0]);
+
+    return $.get("{{ url_for('.closable_railroads') }}")
+        .then(railroadsResponse => {
+            var legalRailroads = railroadsResponse["railroads"];
+            return [
+                closedRailroadRows.filter(railroadName =>
+                        legalRailroads.includes(railroadName) && !getRailroads().includes(railroadName)),
+                railroadsResponse["home-cities"]
+            ];
+        }).then(data => {
+            var railroadNames = data[0];
+            var homeCities = data[1];
+            railroadNames.forEach(railroadName => {
+                var railroadButton = $(`#closed-railroads button[data-railroad='${railroadName}']`);
+                if (railroadButton.length === 0) {
+                    addClosedRailroad(railroadName, homeCities[railroadName]);
+                }
+            });
+
+            // Delete railroads which are in the table but not the import block
+            getClosedRailroads()
+                .filter(railroad => !railroadNames.includes(railroad))
+                .forEach(railroad => {
+                    $(`#closed-railroads button[data-railroad='${railroad}']`).remove()
+                });
+
+            updateLocalStorageClosedRailroads();
+        })
+        .catch(function(jqXHR, textStatus, errorThrown) {
+            console.warn("Failed to import railroads. Continuing...");
+        });
+}
+
+function prepareClosedRailroadsForExport(closedRailroadNames) {
+    return (closedRailroadNames === undefined ? getClosedRailroads() : closedRailroadNames)
+        .map(closedRailroad => `${closedRailroad}; closed`)
+        .join("\n");
+}
+
+function populateCloseRailroadsDropdown(source) {
+    $("#close-railroad-dropdown-list").empty();
+
+    $.get("{{ url_for('.closable_railroads') }}")
+        .done(function(result) {
+            var inactiveRailroads = getRemovedRailroads().concat(getClosedRailroads());
+            result["railroads"]
+                .filter(railroad => !inactiveRailroads.includes(railroad))
+                .forEach(railroad => {
+                $("#close-railroad-dropdown-list")
+                    .append($("<a></a>")
+                        .addClass("dropdown-item")
+                        .attr("data-railroad", railroad)
+                        .attr("href", "#")
+                        .text(railroad)
+                        .click(function() {
+                            var railroad = $(this).attr("data-railroad");
+                            var homeCity = result["home-cities"][railroad];
+                            removeRailroad(railroad);
+                            addClosedRailroad(railroad, homeCity);
+
+                            drawTokens();
+
+                            updateLocalStorageClosedRailroads();
+                        })
+                    );
+            });
+        })
+        .fail(function(jqXHR, textStatus, errorThrown) {
+            console.error("Failed to load the list of closable railroads.");
+            $("#close-railroad-dropdown-list")
+                .append($("<div></div>")
+                    .addClass("dropdown-header")
+                    .css("color", "red")
+                    .text("Failed to load railroads."));
+        });
+}
+
+function toggleEnableClosedRailroads(enable) {
+    $("#closed-railroads").attr("data-disabled", enable ? "false" : "true");
+    $("#closed-railroads button").prop("disabled", !enable);
+    $("#close-railroad-dropdown button").prop("disabled", !enable);
+}
+
+$("#close-railroad-dropdown").on("show.bs.dropdown", function() {
+    populateCloseRailroadsDropdown(this);
+});

--- a/routes18xxweb/templates/js/railroads-table.js.html
+++ b/routes18xxweb/templates/js/railroads-table.js.html
@@ -167,8 +167,8 @@ function importRailroads(importText) {
                     .map(value => value.trim())
                     .filter(value => !isEmpty(value)));
         })
-        // Since the railroads and removed railroads shared a text area, filter out the removed railroads
-        .filter(row => row.length < 2 || isEmpty(row[1][0]) || row[1][0].trim().toLowerCase() !== "removed");
+        // Since the railroads share a text area with the removed and closed railroads, filter out removed and closed
+        .filter(row => row.length < 2 || isEmpty(row[1][0]) || !["removed", "closed"].includes(row[1][0].trim().toLowerCase()));
 
     return $.when(
         $.get("{{ url_for('.legal_railroads') }}"),
@@ -334,19 +334,24 @@ function addTrainAndStationButtons(rowElement) {
             .append($("<span></span>")
                 .addClass("oi oi-delete"))
                 .click(function() {
-                    $(this).parents("tr").remove();
-                    drawTokens();
-
-                    $("#calculate-submit").prop("disabled", !readyToSelectRailroad());
-                    removeAllPrivateCompanies(company => company[1] === $(this).parents("tr").attr("data-railroad"));
-                    updateLocalStorageRailroads();
-                    updatePhase();
-                    drawTokens();
+                    removeRailroad($(this).parents("tr").attr("data-railroad"));
                 }));
 
     if ($("#railroads-table").attr("data-disabled") === "true") {
         $("#railroads-table button").prop("disabled", true);
     }
+}
+
+function removeRailroad(railroad) {
+    var railroadElement = $(`#railroads-table tr[data-railroad='${railroad}']`);
+    railroadElement.remove();
+    drawTokens();
+
+    $("#calculate-submit").prop("disabled", !readyToSelectRailroad());
+    removeAllPrivateCompanies(company => company[1] === railroadElement.attr("data-railroad"));
+    updateLocalStorageRailroads();
+    updatePhase();
+    drawTokens();
 }
 
 function enableSubmitViaKeyboard(modal, submitButton) {
@@ -667,7 +672,7 @@ function populateRailroadsDropdown(source) {
     $.get("{{ url_for('.legal_railroads') }}", {railroads: JSON.stringify(getRailroads())})
         .done(function(result) {
             result["railroads"]
-                .filter(railroad => !getRemovedRailroads().includes(railroad))
+                .filter(railroad => !getRemovedRailroads().includes(railroad) && !getClosedRailroads().includes(railroad))
                 .forEach(railroad => {
                     $("#add-railroad-dropdown-list")
                         .append($("<a></a>")

--- a/routes18xxweb/templates/js/removed-railroads-table.js.html
+++ b/routes18xxweb/templates/js/removed-railroads-table.js.html
@@ -28,7 +28,8 @@ function addRemovedRailroad(railroadName, homeCity) {
             .attr("type", "button")
             .attr("data-railroad", railroadName)
             .attr("data-home", homeCity)
-            .css("margin-right", 5)
+            .css("margin-top", 5)
+            .css("display", "block")
             .append($("<span></span>")
                 .addClass("oi oi-circle-x align-text-top")
                 .css("margin-right", 5))
@@ -103,9 +104,9 @@ function prepareRemovedRailroadsForExport(removedRailroadNames) {
 function populateRemoveRailroadsDropdown(source) {
     $("#remove-railroad-dropdown-list").empty();
 
-    $.get("{{ url_for('.removable_railroads') }}", {railroads: JSON.stringify(getRemovedRailroads())})
+    $.get("{{ url_for('.removable_railroads') }}")
         .done(function(result) {
-            var activeRailroads = getRailroads();
+            var activeRailroads = getRailroads().concat(getRemovedRailroads()).concat(getClosedRailroads());
             result["railroads"]
                 .filter(railroad => !activeRailroads.includes(railroad))
                 .forEach(railroad => {

--- a/routes18xxweb/views/calculate.py
+++ b/routes18xxweb/views/calculate.py
@@ -16,6 +16,7 @@ CALCULATOR_QUEUE = Queue(connection=redis_conn)
 def calculate():
     railroads_state_rows = json.loads(request.form.get("railroads-json"))
     removed_railroads = json.loads(request.form.get("removed-railroads-json"))
+    closed_railroads = json.loads(request.form.get("closed-railroads-json"))
     private_companies_rows = json.loads(request.form.get("private-companies-json"))
     board_state_rows = json.loads(request.form.get("board-state-json"))
     railroad_name = request.form["railroad-name"]
@@ -25,9 +26,11 @@ def calculate():
     LOG.info(f"Private companies: {private_companies_rows}")
     LOG.info(f"Railroad input: {railroads_state_rows}")
     LOG.info(f"Removed railroads: {removed_railroads}")
+    LOG.info(f"Closed railroads: {closed_railroads}")
     LOG.info(f"Board input: {board_state_rows}")
 
     railroads_state_rows += [[name, "removed"] for name in removed_railroads]
+    railroads_state_rows += [[name, "closed"] for name in closed_railroads]
 
     job = CALCULATOR_QUEUE.enqueue(calculate_worker, g.game_name, railroads_state_rows, private_companies_rows, board_state_rows, railroad_name, job_timeout="5m")
 

--- a/routes18xxweb/views/game.py
+++ b/routes18xxweb/views/game.py
@@ -95,6 +95,7 @@ def main():
             stop_names=stop_names,
             termini_boundaries=termini_boundaries,
             removable_railroads=_get_removable_railroads(),
+            closable_railroads=_get_closable_railroads(game),
             board_layout=_get_board_layout_info(),
             migration_data=migration_data)
 
@@ -335,17 +336,32 @@ def _get_removable_railroads():
 def removable_railroads():
     LOG.info("Removable railroads request.")
 
-    existing_railroads = {railroad for railroad in json.loads(request.args.get("railroads", "{}")) if railroad}
-
-    railroads_info = get_railroad_info(g.game_name)
-    all_removable_railroads = _get_removable_railroads()
-    removable_railroads = all_removable_railroads - existing_railroads
+    removable_railroads = _get_removable_railroads()
 
     LOG.info(f"Removable railroads response: {removable_railroads}")
 
+    railroads_info = get_railroad_info(g.game_name)
     return jsonify({
         "railroads": list(sorted(removable_railroads)),
         "home-cities": {railroad: railroads_info[railroad]["home"] for railroad in removable_railroads}
+    })
+
+def _get_closable_railroads(game):
+    return set(get_railroad_info(game).keys()) if game.rules.railroads_can_close else set()
+ 
+@game_app.route("/railroads/closable-railroads")
+def closable_railroads():
+    LOG.info("Closable railroads request.")
+
+    game = get_game(g.game_name)
+    closable_railroads = _get_closable_railroads(game)
+
+    LOG.info(f"Closable railroads response: {closable_railroads}")
+
+    railroads_info = get_railroad_info(game)
+    return jsonify({
+        "railroads": list(sorted(closable_railroads)),
+        "home-cities": {railroad: railroads_info[railroad]["home"] for railroad in closable_railroads}
     })
 
 @game_app.route("/railroads/trains")


### PR DESCRIPTION
Closed railroads can be marked in the "Closed railroads" column. You
can close any railroad that is not already closed or marked as removed.
If you close a railroad that's currently operating, it will be deleted
from the operating list and moved to the closed section. Closed railroads
get their own table in lcoalStorage, so they also show up in the
import/export modal. There's no special UI things for them, since the UI
currently doesn't do anything secial for reserved spaces.

Resolves #75 