### PR TITLE
Highlight tiles with too many stations.

### DIFF
--- a/routes18xxweb/templates/index.html
+++ b/routes18xxweb/templates/index.html
@@ -18,6 +18,7 @@
         <canvas id="placed-tiles-board-canvas"></canvas>
         <canvas id="stations-canvas"></canvas>
         <canvas id="routes-canvas"></canvas>
+        <canvas id="station-overload-canvas"></canvas>
         <canvas id="tile-focus-canvas"></canvas>
     </div>
     <div style="float: left; width: 2%;">&nbsp;</div>
@@ -257,7 +258,7 @@ function loadGameState() {
             .attr("width", mapImage.clientWidth)
             .css("text-align", "center");
 
-        $("#placed-tiles-board-canvas, #tile-focus-canvas, #stations-canvas, #routes-canvas")
+        $("#placed-tiles-board-canvas, #station-overload-canvas, #stations-canvas, #routes-canvas, #tile-focus-canvas")
             .css("position", "absolute")
             .css("left", mapImage.offsetLeft)
             .css("top", mapImage.offsetTop)

--- a/routes18xxweb/templates/js/placed-tiles-map.js.html
+++ b/routes18xxweb/templates/js/placed-tiles-map.js.html
@@ -130,25 +130,43 @@ function keepHighlightVisible(tilePoints) {
 
 }
 
-function highlightCoord(coord) {
+function outlineCoord(coord, canvasId, outlineColor) {
     var mapImg = $("#placed-tiles-board").get(0);
-    var focusCanvas = $("#tile-focus-canvas").get(0);
-    var context = focusCanvas.getContext('2d');
+    var outlineCanvas = $(canvasId).get(0);
 
     var rowAndCol = coordToRowAndCol(coord);
-    var tilePoints = getTilePoints(focusCanvas, rowAndCol.row, rowAndCol.col);
+    var tilePoints = getTilePoints(outlineCanvas, rowAndCol.row, rowAndCol.col);
 
-    var focusContext = focusCanvas.getContext("2d");
-    focusContext.strokeStyle = "#00ffff";
-    focusContext.shadowBlur = 20;
-    focusContext.shadowColor = "#00ffff";
-    focusContext.lineWidth = 3;
-    focusContext.beginPath();
-    focusContext.moveTo(tilePoints[0].x, tilePoints[0].y);
-    tilePoints.slice(1).forEach(point => focusContext.lineTo(point.x, point.y));
-    focusContext.closePath();
-    focusContext.stroke();
+    var outlineContext = outlineCanvas.getContext("2d");
 
+    // Store current context settings
+    var strokeStyle = outlineContext.strokeStyle;
+    var shadowBlur = outlineContext.shadowBlur;
+    var shadowColor = outlineContext.shadowColor;
+    var lineWidth = outlineContext.lineWidth;
+
+    // Draw outline
+    outlineContext.strokeStyle = outlineColor;
+    outlineContext.shadowBlur = 20;
+    outlineContext.shadowColor = outlineColor;
+    outlineContext.lineWidth = 3;
+    outlineContext.beginPath();
+    outlineContext.moveTo(tilePoints[0].x, tilePoints[0].y);
+    tilePoints.slice(1).forEach(point => outlineContext.lineTo(point.x, point.y));
+    outlineContext.closePath();
+    outlineContext.stroke();
+
+    // Restore context settings
+    outlineContext.strokeStyle = strokeStyle;
+    outlineContext.shadowBlur = shadowBlur;
+    outlineContext.shadowColor = shadowColor;
+    outlineContext.lineWidth = lineWidth;
+
+    return tilePoints;
+}
+
+function highlightSelectedCoord(coord) {
+    var tilePoints = outlineCoord(coord, "#tile-focus-canvas", "#00ffff");
     keepHighlightVisible(tilePoints);
 }
 
@@ -215,7 +233,7 @@ function removeTileFromMap(coord) {
     mapContext.globalCompositeOperation = 'source-over';
 }
 
-function drawTokens() {
+async function drawTokens() {
     var stationCanvas = $("#stations-canvas").get(0);
     stationCanvas.getContext('2d').clearRect(0, 0, stationCanvas.width, stationCanvas.height);
 
@@ -244,12 +262,22 @@ function drawTokens() {
         stationCountByCoord[coord]++;
     });
 
-    getPhase()
+    await getPhase()
         .done(phase => {
             getPrivateCompaniesAsTable().forEach(company => {
                 drawPrivateCompanyTokensHook(phase, company, stationCountByCoord);
             });
         });
+
+    var canvas =  $("#station-overload-canvas").get(0);
+    canvas.getContext('2d').clearRect(0, 0, canvas.width, canvas.height);
+    Object.keys(stationCountByCoord).forEach(coord => {
+        ifSpaceOverloaded(coord,
+            () => {
+                outlineCoord(coord, "#station-overload-canvas", "#ff0000");
+            }
+        );
+    });
 }
 
 function drawPrivateCompanyOnMap(coord, privateCompanyName) {
@@ -588,6 +616,7 @@ function tileModalStationEntry(coord, railroadName) {
                     removeRailroadStation(getRailroadRow(railroadName), coord);
                     populateStations(coord);
                     drawTokens();
+                    setTileSelectorModalMessage(coord);
                     clearCalculateTab();
 
                     updateLocalStorageRailroads();
@@ -692,6 +721,7 @@ function populateTileSelectorStationDropdown(sourceRow, coord) {
                         addRailroadStation(row, coord);
                         populateStations(coord);
                         drawTokens();
+                        setTileSelectorModalMessage(coord);
                         clearCalculateTab();
 
                         updateLocalStorageRailroads();
@@ -876,7 +906,6 @@ function populateTiles(coord) {
 
     $.get("{{ url_for('.legal_tiles') }}", {coord: coord})
         .then(function(result) {
-
             for (index in result["legal-tile-ids"]) {
                 var tileId = result["legal-tile-ids"][index];
                 var tileIdStr = tileId.toString().padStart(3, "0");
@@ -946,6 +975,23 @@ function setTileSelectorModalHeader(coord) {
     }
 }
 
+function setTileSelectorModalMessage(coord) {
+    ifSpaceOverloaded(coord,
+        (capacity, stations, unclaimedReservations) => {
+            if (stations.length > capacity) {
+                var stationWord = stations.length === 1 ? "station" : "stations";
+                $("#tile-selector-modal-message").text(`Contains ${stations.length} ${stationWord}, but capacity is ${capacity}.`);
+            } else {
+                $("#tile-selector-modal-message").text(`Not enough room for some reservations (${unclaimedReservations.join(", ")}).`);
+            }
+            updateTileSelectionViewport();
+        },
+        () => {
+            $("#tile-selector-modal-message").empty();
+            updateTileSelectionViewport();
+        });
+}
+
 function keepOnScreen(viewport, content) {
     // Don't let the bottom of the tile orientation list pass the bottom of the modal viewport
     var viewportBottom = viewport.offset().top + viewport.height();
@@ -999,8 +1045,9 @@ function openTileSelectionModal(rowAndCol, pointOnImage) {
 
                 clearAllHighlights();
                 setTileSelectorModalHeader(clickableTerminusCoord);
+                setTileSelectorModalMessage(clickableTerminusCoord);
                 populatePrivateCompanies(clickableTerminusCoord);
-        
+
                 $("#tile-selector-tiles").hide();
                 $("#tile-selector-stations").hide();
                 $("#tile-selector").modal("show");
@@ -1009,8 +1056,9 @@ function openTileSelectionModal(rowAndCol, pointOnImage) {
         var coord = rowAndColToCoord(rowAndCol);
         if (legalCoords.includes(coord)) {
             clearAllHighlights();
-            highlightCoord(coord);
+            highlightSelectedCoord(coord);
             setTileSelectorModalHeader(coord);
+            setTileSelectorModalMessage(coord);
             populateTiles(coord);
             populateStations(coord);
             populatePrivateCompanies(coord);
@@ -1049,7 +1097,19 @@ $("#tile-selector").on("show.bs.modal", function() {
 $("#tile-selector").on("shown.bs.modal", function() {
     keepOnScreen($("#tile-selector-tiles-content"), $("#tile-orientations"));
     $("#tile-selector-modal-body-tabs .nav-item a:visible").first().click();
+
+    updateTileSelectionViewport();
 });
+
+function updateTileSelectionViewport() {
+    // Resize tile selection window to exactly fix within the modal body viewport.
+    var modalBody = $("#tile-selector-modal-body-tabs-content").parent();
+    $("#tile-selector-tiles-content").height(
+        // The height of the modal body viewport.
+        modalBody.innerHeight()
+        // The offset of the tile selector viewport, which is impacted by both the tab bar and the message section.
+        - ($("#tile-selector-modal-body-tabs-content").offset().top - modalBody.offset().top));
+}
 
 $("#tile-selector").on("hidden.bs.modal", function() {
     currentCoordFocus = $('#tile-selector').attr("data-coord");
@@ -1125,7 +1185,7 @@ $("#placed-tiles-board").focus(canDisable(function(event) {
     }
 
     clearAllHighlights();
-    highlightCoord(currentCoordFocus);
+    highlightSelectedCoord(currentCoordFocus);
 }));
 
 $("#placed-tiles-board").keydown(canDisable(function(event) {
@@ -1154,7 +1214,7 @@ $("#placed-tiles-board").keydown(canDisable(function(event) {
 
         clearAllHighlights();
         if (currentCoordFocus !== undefined) {
-            highlightCoord(currentCoordFocus);
+            highlightSelectedCoord(currentCoordFocus);
         }
     } else if (event.key === "Enter") {
         openTileSelectionModal(coordToRowAndCol(currentCoordFocus));
@@ -1180,7 +1240,7 @@ $("#placed-tiles-board").keydown(canDisable(function(event) {
         if (legalCoords.includes(newCoord)) {
             currentCoordFocus = newCoord;
             clearAllHighlights();
-            highlightCoord(currentCoordFocus);
+            highlightSelectedCoord(currentCoordFocus);
         }
     }
 }));

--- a/routes18xxweb/templates/js/placed-tiles-table.js.html
+++ b/routes18xxweb/templates/js/placed-tiles-table.js.html
@@ -78,7 +78,8 @@ function getTileInfo(coord, successCallback, failureCallback) {
     var tile = tilesTable.find(row => row[0] === coord);
     var tileId = isEmpty(tile) ? null : tile[1];
     var orientation = isEmpty(tile) ? null : tile[2];
-    $.get("{{ url_for('.board_space_info') }}", {coord: coord, orientation: orientation, tileId: tileId})
+    var phase = $("#board-phase").text();
+    $.get("{{ url_for('.board_space_info') }}", {coord: coord, tileId: tileId, orientation: orientation, phase: phase})
         .done(function(response) {
             var info = response["info"];
             info["orientation"] = isEmpty(tile) ? null : tile[2];
@@ -90,6 +91,37 @@ function getTileInfo(coord, successCallback, failureCallback) {
             console.error(`Failed to get tile info for ${coord}.`);
             if (!isEmpty(failureCallback)) {
                 failureCallback(jqXHR, textStatus, errorThrown);
+            }
+        });
+}
+
+function ifSpaceOverloaded(coord, overloadedCallback, notOverloadedCallback) {
+    var phase = $("#board-phase").text();
+    var stations = getRailroadsAtCoord(coord, phase)
+            .concat(getRemovedRailroadsAtCoord(coord, phase))
+            .map(railroadRow => railroadRow[0]);
+    getTileInfo(coord,
+        tileInfo => {
+            var capacity = tileInfo["capacity"];
+            var stationCount = stations.length;
+
+            var unclaimedReservations =
+                tileInfo["home-to"]
+                    .filter(railroad => !stations.includes(railroad))
+                    .concat(tileInfo["reserved-for"]
+                        .filter(railroad => !getRemovedRailroads().includes(railroad)
+                            && !getClosedRailroads().includes(railroad)
+                            && !stations.includes(railroad)));
+
+            var callbackArgs = [capacity, stations, unclaimedReservations, tileInfo["home-to"], tileInfo["reserved-for"]];
+            if (stationCount > capacity - unclaimedReservations.length) {
+                if (!isEmpty(overloadedCallback)) {
+                    overloadedCallback(...callbackArgs);
+                }
+            } else {
+                if (!isEmpty(notOverloadedCallback)) {
+                    notOverloadedCallback(...callbackArgs);
+                }
             }
         });
 }

--- a/routes18xxweb/templates/js/removed-railroads-table.js.html
+++ b/routes18xxweb/templates/js/removed-railroads-table.js.html
@@ -13,6 +13,13 @@ function getRemovedRailroadsAsTable() {
     return removedRailroadsTableData;
 }
 
+function getRemovedRailroadsAtCoord(cell, phase) {
+    return getRemovedRailroadsAsTable()
+        .filter(railroad => {
+            return railroad[1].split(",").find(stationCoord => cell === stationCoord.trim().split(':')[0]) !== undefined;
+        });
+}
+
 function deleteRemovedRailroad(railroad) {
     $(`#removed-railroads button[data-railroad='${railroad}']`).remove();
 

--- a/routes18xxweb/templates/placed-tiles-modals.html
+++ b/routes18xxweb/templates/placed-tiles-modals.html
@@ -9,6 +9,8 @@
                 </button>
             </div>
             <div class="modal-body" style="padding-top: 0px; padding-bottom: 0px; overflow-y: auto;">
+                <div id="tile-selector-modal-message" style="color: red; font-size: 100%;"></div>
+                <hr style="margin-top: 1px; margin-bottom: 5px;" />
                 <ul class="nav nav-pills" id="tile-selector-modal-body-tabs" role="tablist" style="padding-bottom: 10px;">
                     <li class="nav-item">
                         <a class="nav-link active" id="tile-selector-tiles" data-toggle="tab" href="#tile-selector-tiles-content" role="tab" aria-controls="tile-selector-tiles" aria-selected="true">Tiles</a>


### PR DESCRIPTION
If a tile has too many stations, or there's no slot remaining for a home
or reserved station, it is outlined in red. An error message is displayed
in the tile seelctor modal across all tabs. To facilitate this, the tile
selecion viewport is resized as needed to keep the message on the screen,
and to prevent a double scroll bar,

Resolves #68 