### PR TITLE
Three small tweaks

### DIFF
--- a/routes18xxweb/templates/js/placed-tiles-map.js.html
+++ b/routes18xxweb/templates/js/placed-tiles-map.js.html
@@ -704,9 +704,10 @@ function populateTileSelectorStationDropdown(sourceRow, coord) {
     var dropdownMenu = sourceRow.find(".dropdown-menu");
     dropdownMenu.empty();
 
+    var cell = coord.split(':')[0];
     getRailroadsAsTable()
         .forEach(railroad => {
-            if (railroad[2].split(",").includes(coord)) {
+            if (railroad[2].split(",").map(stationCoord => stationCoord.split(':')[0]).includes(cell)) {
                 return
             }
 

--- a/routes18xxweb/templates/js/placed-tiles-table.js.html
+++ b/routes18xxweb/templates/js/placed-tiles-table.js.html
@@ -75,11 +75,12 @@ function removeTile(coord) {
 }
 
 function getTileInfo(coord, successCallback, failureCallback) {
+    [cell, branch] = coord.split(":");
     var tile = tilesTable.find(row => row[0] === coord);
     var tileId = isEmpty(tile) ? null : tile[1];
     var orientation = isEmpty(tile) ? null : tile[2];
     var phase = $("#board-phase").text();
-    $.get("{{ url_for('.board_space_info') }}", {coord: coord, tileId: tileId, orientation: orientation, phase: phase})
+    $.get("{{ url_for('.board_space_info') }}", {coord: cell, tileId: tileId, orientation: orientation, phase: phase})
         .done(function(response) {
             var info = response["info"];
             info["orientation"] = isEmpty(tile) ? null : tile[2];

--- a/routes18xxweb/templates/js/railroads-table.js.html
+++ b/routes18xxweb/templates/js/railroads-table.js.html
@@ -454,6 +454,7 @@ function populateStationsModal(source) {
     $.get("{{ url_for('.cities') }}")
         .done(function(result) {
             var splitCities = result["split-cities"];
+            var uneditableStations = getRailroadFixedStations(railroad);
             result["cities"].forEach(cell => {
                 var cityItemText = (stopNames.hasOwnProperty(cell) ? stopNames[cell] : cell) + ` (${cell})`;
                 var cityItem = $("<button></button>")
@@ -537,9 +538,9 @@ function populateStationsModal(source) {
                         }
                     });
                 } else {
-                   var uneditableStations = getRailroadFixedStations(railroad);
-
-                    if (!uneditableStations.includes(cell)) {
+                    if (uneditableStations.includes(cell)) {
+                        cityItem.addClass("bg-secondary");
+                    } else {
                         cityItem.click(function() {
                             if ($(this).hasClass("active")) {
                                 $(this).removeClass("active");


### PR DESCRIPTION
- In the station selector, display uneditable stations (such as home stations) with a gray background
- In the station tab of the tile modal selector, only allow 1 station per railroad on split cities.
- Update getTileInfo to handle split cities.

Resolves #81 
Resolves #5 